### PR TITLE
[release=patch] Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Internationalise your app, extending config or factory new internationalised components.
 
 [![NPM](https://img.shields.io/npm/v/react-i18n-base.svg?style=flat-square) ![NPM](https://img.shields.io/npm/dm/react-i18n-base.svg?style=flat-square)](https://www.npmjs.com/package/react-i18n-base)
-[![Build Status](https://img.shields.io/travis/daniloster/react-i18n-base/master.svg?style=flat-square)](https://travis-ci.org/daniloster/react-i18n-base) [![BCH compliance](https://bettercodehub.com/edge/badge/daniloster/react-i18n-base?branch=master)](https://bettercodehub.com/)
+[![Build Status](https://img.shields.io/travis/daniloster/react-i18n-base/master.svg?style=flat-square)](https://travis-ci.org/daniloster/react-i18n-base)
 
 ## Docs
 
+- [Home Page](http://codeinbox.me/react-i18n-base/)
 - [react-i18n-base](https://github.com/daniloster/react-i18n-base/blob/master/README.md)
 - [react-i18n-base/API](https://github.com/daniloster/react-i18n-base/blob/master/API.md)
 
@@ -119,13 +120,10 @@ App
 // Initialising the app
 //----------------------------------------------//
 import { I18nProvider } from 'react-i18n-base';
-// If you have the redux store provider wrapping and want to
-// feed information from its state to the provider component,
-// it is possible. Only need to create a mapStateToProps and
-// an action to change the locale through reducer.
 
 const App = () => (
   <div>
+    {/* If only defaultLanguage is set, then, initialLanguage will be the defaultLanguage value  */}
     <I18nProvider defaultLanguage="en">
       <Greeting /> {/* it will get the correct i18n object */}
       <LabelForm isError />

--- a/package.json
+++ b/package.json
@@ -2,6 +2,18 @@
   "name": "react-i18n-base",
   "version": "3.0.0",
   "main": "lib/index.js",
+  "homepage": "http://codeinbox.me/react-i18n-base",
+  "author": {
+    "name": "Danilo Castro",
+    "url": "https://github.com/daniloster"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daniloster/react-i18n-base.git"
+  },
+  "bugs": {
+    "url": "https://github.com/daniloster/react-i18n-base/issues"
+  },
   "license": "MIT",
   "nyc": {
     "require": [
@@ -93,7 +105,6 @@
     "prettier": "1.16.4",
     "prop-types": "15.7.2",
     "react": "16.8.4",
-    "react-i18n-base": "1.4.1",
     "react-addons-test-utils": "15.6.2",
     "react-docgen": "4.1.0",
     "react-docgen-displayname-handler": "2.1.1",


### PR DESCRIPTION
Changes

- Updated README to point to the react-i18n-base static website
- Added references to author, homepage, repository and bugs in the package.json exposing it to the npm
- Removed reference to itself in the dependencies 🦆 